### PR TITLE
Return relative batch-results downloadUrl for sub-path proxy

### DIFF
--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -542,8 +542,11 @@ app.get("/api/batch-status/:id", (c) => {
 		processed: job.processed,
 		errors: job.errors,
 		error: job.errorMessage,
+		// Relative URL so it resolves under the app's base path (e.g. behind an
+		// IIS sub-path reverse proxy). An absolute "/api/..." would hit the site
+		// root, which proxies to a different service.
 		downloadUrl:
-			job.status === "completed" ? `/api/batch-results/${job.id}` : undefined,
+			job.status === "completed" ? `./api/batch-results/${job.id}` : undefined,
 	});
 });
 


### PR DESCRIPTION
The batch-status response returned an absolute downloadUrl (/api/batch-results/ID). Behind the IIS sub-path reverse proxy (/ebd-address-tool/batch/), an absolute /api/... resolves to the site root, which proxies to the backend service (3000) instead of the batch tool (3001) -> HTML 404 on download. Make it relative (./api/batch-results/ID) like the other client calls so it resolves under the app base path.