### PR TITLE
Stop logging addresses (PII) to batch-tool log files

### DIFF
--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -356,7 +356,8 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 
 		return { ok: true, data: result };
 	} catch (err) {
-		console.error("Address lookup failed:", address, err);
+		// Do not log the address (PII).
+		console.error("Address lookup failed:", err);
 		return { ok: false, error: "Address lookup failed", status: 500 };
 	}
 }
@@ -407,7 +408,8 @@ async function processBatchFile(job: BatchJob, file: File) {
 						}
 					})
 					.catch((err) => {
-						console.error("Error processing address:", address, err);
+						// Do not log the address (PII).
+						console.error("Error processing an address:", err);
 						job.errors += 1;
 						job.results.push({
 							InputAddress: address,


### PR DESCRIPTION
Stops the batch-tool from writing user-entered addresses (PII) to its log file.

The two `console.error` calls in the address-lookup and batch-processing paths included the raw address, which is persisted to `batch-backend.out.log`. Both now log only the error object.

Addresses still live only in:
- the in-memory `/api/errors` log (RAM, cleared on restart) — kept intentionally for diagnostics
- the downloadable results CSV

No behavior change beyond logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)