### PR TITLE
Require CFA membership for Central eligibility

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ interface TractInfo {
 	tract: string;
 	region: string;
 	eligible: string; // "true"/"false"
+	CFA: string; // CFA label; empty when the tract is not a CFA
 }
 
 const tractData: TractInfo[] = Papa.parse<TractInfo>(
@@ -325,9 +326,12 @@ app.post("/api/overlay", async (c) => {
 				county_income: countyIncome,
 			});
 
-		// Central region - eligibility is now driven by DAC tract membership or
-		// the 1/2-mile DAC buffer, not by the per-tract `eligible` column.
-		if (tractInfo.region === "Central" && geoEligible) {
+		// Central region - eligibility requires the tract to be a CFA (the `CFA`
+		// column is populated in tracts.csv) AND to meet the DAC tract membership
+		// or 1/2-mile DAC buffer rule. Tracts that aren't CFAs are not eligible
+		// regardless of DAC status.
+		const isCfa = Boolean(tractInfo.CFA?.trim());
+		if (tractInfo.region === "Central" && isCfa && geoEligible) {
 			const message = `
 				It appears that your address may be within the eligible area for this program.
 				Please review the table below to see if your household income also meets the eligibility requirements.
@@ -353,9 +357,10 @@ app.post("/api/overlay", async (c) => {
 			});
 		}
 
-		// Central region - in service area but not in a DAC and not within
-		// 1/2 mile of one, so not currently eligible. Uses the default
-		// "program is growing" message.
+		// Central region - in the service area but not currently eligible, either
+		// because the tract isn't a CFA (`central_not_cfa`) or because it is a CFA
+		// but isn't a DAC / within 1/2 mile of one (`central_not_dac`). Both use
+		// the default "program is growing" message.
 		const notEligibleMessage = `Looks like your area isn't eligible yet. We're growing! Check back soon or
 			<a href="${SIGNUP_URL}" target="_blank" rel="noopener noreferrer">join our mailing list</a>
 			to stay informed as the program expands to your community.`;
@@ -365,7 +370,7 @@ app.post("/api/overlay", async (c) => {
 			tract: displayTract,
 			message: notEligibleMessage,
 			region: "Central",
-			reason: "central_not_dac",
+			reason: isCfa ? "central_not_dac" : "central_not_cfa",
 			action: "visit-signup",
 			signup_url: SIGNUP_URL,
 			carb_priority: { is_priority: isPriority, label: carbRaw || "" },

--- a/batch-tool/data/addresses.csv
+++ b/batch-tool/data/addresses.csv
@@ -5,3 +5,4 @@ address
 3980 Sherman St San Diego CA 92110
 "4725 Cebrian Ave, New Cuyama, CA, 93254"
 "1481 E Palo Alto Ave, Fresno, CA, 93710"
+2831 Silva St Stockton CA 95205


### PR DESCRIPTION
## What

Add a **CFA prerequisite** to Central-region eligibility in the public-facing widget backend (`/api/overlay`).

Previously, a Central tract qualified if it was a DAC **or** within ½ mile of a DAC. Now a tract must **also be a designated CFA** — the `CFA` column in `tracts.csv` must be non-empty — before the DAC / ½-mile rule is applied. Tracts that are not CFAs are no longer eligible regardless of DAC status.

## Why

Eligibility should be scoped to the program's CFA (designated funding) areas first, then qualified by DAC status within those areas.

## Changes

- `backend/src/index.ts`
  - Add `CFA` to the `TractInfo` interface.
  - Gate the Central "eligible" branch on `isCfa && geoEligible` (CFA membership **and** DAC / ½-mile DAC).
  - Distinguish the two not-eligible Central cases via the response `reason`:
    - `central_not_cfa` — tract is not a CFA
    - `central_not_dac` — tract is a CFA but not a DAC (or within ½ mile)
  - Both keep the existing "program is growing" message.
- `batch-tool/data/addresses.csv`
  - Add `2831 Silva St, Stockton CA 95205` (a DAC tract with no CFA) as a QC fixture for the new not-eligible-without-CFA path.

## QC (ran updated backend locally against addresses.csv)

| Address | Tract | CFA? | DAC? | Eligible | Reason |
|---|---|---|---|---|---|
| 2600 Fresno St, Fresno | 6019000602 | ✅ | ✅ | **true** | `in_dac` |
| 1481 E Palo Alto Ave, Fresno | 6019005406 | ✅ | ❌ | false | `central_not_dac` |
| **2831 Silva St, Stockton** | 6077002100 | ❌ | ✅ | **false** | `central_not_cfa` |
| 5600 Edgemont Dr, Bakersfield | 6029002816 | ❌ | ❌ | false | `central_not_cfa` |
| 4725 Cebrian Ave, New Cuyama | 6083001800 | ❌ | ❌ | false | `central_not_cfa` |
| 27272 Willowbank Rd, Davis | — | — | — | false | Northern (redirect) |
| 3980 Sherman St, San Diego | — | — | — | false | Southern (redirect) |

The Stockton address — eligible (`in_dac`) before this change — is now correctly **not eligible** because its tract is a DAC but not a CFA. Genuinely-eligible CFA+DAC tracts (2600 Fresno St) are unaffected.

## Notes

- This PR targets `main`, which already contains the DAC / ½-mile buffer work this builds on (merged via #12/#15/#16).
- Eligibility here is geographic only; applicants must still meet income thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
