### PR TITLE
Batch tool: flexible CSV formats, concurrency fix, reliability improvements

### DIFF
--- a/batch-tool/.gitignore
+++ b/batch-tool/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# ad-hoc test CSVs (not part of the repo)
+data/test_*.csv

--- a/batch-tool/README.md
+++ b/batch-tool/README.md
@@ -40,7 +40,7 @@ Optional tuning variables (all have sensible defaults):
 | ------------------------ | ----------- | -------------------------------------------------- |
 | `PORT`                   | `3100`      | HTTP listen port                                   |
 | `BATCH_CONCURRENCY`      | `3`         | Max addresses geocoded in parallel per job         |
-| `MAX_REQUEST_BODY_SIZE`  | `256 MiB`   | Upload size limit (bytes)                           |
+| `MAX_REQUEST_BODY_SIZE`  | `256 MiB`   | Upload size limit (bytes)                          |
 | `JOB_TTL_MS`             | `1800000`   | How long a finished job's results stay in memory   |
 
 Run:
@@ -79,7 +79,11 @@ misspellings at the cost of looser matching.
 
 ## Input CSV format
 
-A header row with an `address` column is required. One full address per row:
+The tool accepts two address layouts — single-column or multi-column. Column names are **case-insensitive**.
+
+### Single-column (full address)
+
+Include an `address` column with one complete address per row:
 
 ```csv
 address
@@ -95,6 +99,26 @@ address
 > "4725 Cebrian Ave, New Cuyama, CA, 93254"
 > ```
 
+### Multi-column (street, city, state, zip)
+
+Include separate columns for the address parts. At minimum you need a street column plus at least one of city, state, or zip:
+
+```csv
+street,city,state,zip
+2600 Fresno St,Fresno,CA,93721
+27272 Willowbank Rd,Davis,CA,95618
+```
+
+Recognized column name aliases (matching is case-insensitive):
+
+- **Full address:** `address`, `full address`, `full_address`
+- **Street:** `street`, `street address`, `street_address`, `address1`, `address_1`, `addr`, `addr1`, `address:street`
+- **City:** `city`, `city name`, `city_name`, `municipality`, `address:city`
+- **State:** `state`, `st`, `state code`, `state_code`, `address:state`
+- **Zip:** `zip`, `zip code`, `zip_code`, `zipcode`, `postal code`, `postal_code`, `address:zip`
+
+If no recognized address column is found the job fails immediately with a message listing the column names that were found.
+
 A sample file is provided at [`data/addresses.csv`](data/addresses.csv).
 
 ---
@@ -102,13 +126,13 @@ A sample file is provided at [`data/addresses.csv`](data/addresses.csv).
 ## API reference
 
 | Method & path                | Description                                                        |
-| ---------------------------- | ----------------------------------------------------------------- |
+| ---------------------------- | ------------------------------------------------------------------ |
 | `POST /api/upload-csv`       | Upload a CSV (`file` form field). Returns `{ jobId }` (202).       |
-| `GET  /api/batch-status/:id` | Job progress + `downloadUrl` when complete.                       |
+| `GET  /api/batch-status/:id` | Job progress + `downloadUrl` when complete.                        |
 | `GET  /api/batch-results/:id`| Results CSV download (only when job is `completed`).               |
-| `POST /api/lookup-single`    | Look up a single address (`{ "address": "..." }`).                |
-| `GET  /api/errors`           | Recent address-lookup failures (see below).                       |
-| `GET  /api/health`           | Liveness check.                                                   |
+| `POST /api/lookup-single`    | Look up a single address (`{ "address": "..." }`).                 |
+| `GET  /api/errors`           | Recent address-lookup failures (see below).                        |
+| `GET  /api/health`           | Liveness check.                                                    |
 
 ### `GET /api/errors`
 

--- a/batch-tool/README.md
+++ b/batch-tool/README.md
@@ -36,12 +36,13 @@ PORT=8282
 
 Optional tuning variables (all have sensible defaults):
 
-| Variable                 | Default     | Purpose                                            |
-| ------------------------ | ----------- | -------------------------------------------------- |
-| `PORT`                   | `3100`      | HTTP listen port                                   |
-| `BATCH_CONCURRENCY`      | `3`         | Max addresses geocoded in parallel per job         |
-| `MAX_REQUEST_BODY_SIZE`  | `256 MiB`   | Upload size limit (bytes)                          |
-| `JOB_TTL_MS`             | `1800000`   | How long a finished job's results stay in memory   |
+| Variable                 | Default     | Purpose                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------- |
+| `PORT`                   | `3100`      | HTTP listen port                                           |
+| `BATCH_CONCURRENCY`      | `3`         | Max addresses geocoded in parallel per job                 |
+| `MAX_ACTIVE_JOBS`        | `3`         | Max concurrent batch jobs; returns 429 when exceeded       |
+| `MAX_REQUEST_BODY_SIZE`  | `256 MiB`   | Upload size limit (bytes)                                  |
+| `JOB_TTL_MS`             | `1800000`   | How long a finished job's results stay in memory           |
 
 Run:
 

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -289,9 +289,9 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 		// it does not support the Authorization header for this endpoint.
 		const smartyUrl = (match: string) =>
 			`https://us-street.api.smarty.com/street-address?auth-id=${SMARTY_AUTH_ID}&auth-token=${SMARTY_AUTH_TOKEN}&street=${encodeURIComponent(address)}&match=${match}`;
-		const smartyOpts = { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
-
-		let smartyResp = await fetch(smartyUrl("enhanced"), smartyOpts);
+		let smartyResp = await fetch(smartyUrl("enhanced"), {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
 		if (smartyResp.status === 429) {
 			return {
 				ok: false,
@@ -311,7 +311,9 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 
 		if (!smartyData?.length) {
 			// Only fall back when enhanced returned 200 with no candidates.
-			smartyResp = await fetch(smartyUrl("invalid"), smartyOpts);
+			smartyResp = await fetch(smartyUrl("invalid"), {
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			});
 			if (smartyResp.status === 429) {
 				return {
 					ok: false,

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -123,7 +123,7 @@ const MAX_REQUEST_BODY_SIZE = (() => {
 		: DEFAULT_MAX_REQUEST_BODY_SIZE;
 })();
 
-const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 20_000;
 const MAX_ADDRESS_LENGTH = 500;
 
 const DEFAULT_BATCH_CONCURRENCY = 3;
@@ -406,6 +406,14 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 
 		return { ok: true, data: result };
 	} catch (err) {
+		if (err instanceof Error && err.name === "TimeoutError") {
+			return {
+				ok: false,
+				error:
+					"Request timed out — try a smaller batch or wait before retrying",
+				status: 500,
+			};
+		}
 		// Do not log the address (PII).
 		console.error("Address lookup failed:", err);
 		return { ok: false, error: "Address lookup failed", status: 500 };

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -362,6 +362,67 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 	}
 }
 
+class UserError extends Error {}
+
+const ADDRESS_COLUMN_ALIASES: Record<string, string[]> = {
+	full: ["address", "full address", "full_address"],
+	street: [
+		"address:street",
+		"street",
+		"street address",
+		"street_address",
+		"address1",
+		"address_1",
+		"addr",
+		"addr1",
+	],
+	city: ["address:city", "city", "city name", "city_name", "municipality"],
+	state: ["address:state", "state", "st", "state code", "state_code"],
+	zip: [
+		"address:zip",
+		"zip",
+		"zip code",
+		"zip_code",
+		"zipcode",
+		"postal code",
+		"postal_code",
+	],
+};
+
+type AddressColumnMap = Partial<
+	Record<"full" | "street" | "city" | "state" | "zip", string>
+>;
+
+function detectAddressColumns(fields: string[]): AddressColumnMap | null {
+	const map: AddressColumnMap = {};
+	for (const field of fields) {
+		const lower = field.toLowerCase().trim();
+		for (const [role, aliases] of Object.entries(ADDRESS_COLUMN_ALIASES)) {
+			if (aliases.includes(lower)) {
+				map[role as keyof AddressColumnMap] = field;
+				break;
+			}
+		}
+	}
+	if (map.full) return map;
+	if (map.street && (map.city || map.state || map.zip)) return map;
+	return null;
+}
+
+function extractAddress(
+	row: Record<string, string | undefined>,
+	map: AddressColumnMap,
+): string | undefined {
+	if (map.full) return row[map.full]?.trim();
+	const parts = (["street", "city", "state", "zip"] as const)
+		.map((role) => {
+			const col = map[role];
+			return col ? row[col]?.trim() : undefined;
+		})
+		.filter(Boolean);
+	return parts.length ? parts.join(", ") : undefined;
+}
+
 async function processBatchFile(job: BatchJob, file: File) {
 	const maxConcurrent = Math.max(1, BATCH_CONCURRENCY);
 	let pending = 0;
@@ -382,12 +443,30 @@ async function processBatchFile(job: BatchJob, file: File) {
 				? readable.fromWeb(file.stream())
 				: Readable.from(file.stream() as unknown as AsyncIterable<unknown>);
 
-		Papa.parse<{ address?: string }>(fileStream, {
+		let columnMap: AddressColumnMap | undefined;
+		let detectionError: string | null = null;
+
+		Papa.parse<Record<string, string>>(fileStream, {
 			header: true,
 			skipEmptyLines: true,
 			step: (row, parser) => {
 				parserRef = parser;
-				const address = row.data?.address?.trim();
+
+				if (columnMap === undefined) {
+					const fields = row.meta.fields ?? [];
+					const detected = detectAddressColumns(fields);
+					if (detected === null) {
+						detectionError =
+							`No recognized address column found. Expected an "address" column, ` +
+							`or columns for street and city/state/zip (e.g., "street", "city", "state", "zip"). ` +
+							`Found: ${fields.length ? fields.join(", ") : "(no headers)"}`;
+						parser.abort();
+						return;
+					}
+					columnMap = detected;
+				}
+
+				const address = extractAddress(row.data, columnMap);
 				if (!address) return;
 
 				job.total += 1;
@@ -430,6 +509,10 @@ async function processBatchFile(job: BatchJob, file: File) {
 					});
 			},
 			complete: () => {
+				if (detectionError) {
+					reject(new UserError(detectionError));
+					return;
+				}
 				parseDone = true;
 				checkDone();
 			},
@@ -440,9 +523,11 @@ async function processBatchFile(job: BatchJob, file: File) {
 	try {
 		await waitForAll;
 	} catch (err) {
-		console.error("Batch CSV parsing failed:", err);
+		if (!(err instanceof UserError))
+			console.error("Batch CSV parsing failed:", err);
 		job.status = "failed";
-		job.errorMessage = "CSV parsing failed";
+		job.errorMessage =
+			err instanceof UserError ? err.message : "CSV parsing failed";
 		job.finishedAt = Date.now();
 		return;
 	}

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -10,6 +10,11 @@ import Papa from "papaparse";
 
 import XLSX from "xlsx";
 
+// Bun-specific: import.meta.dir is the directory of this source file.
+// Using it (rather than process.cwd()) anchors static-file paths to the
+// project layout regardless of which directory the server is started from.
+const __dir = (import.meta as unknown as { dir: string }).dir;
+
 // --- Load CFA tract lookup (tract ID → CFA label) ---
 const NOT_IN_ICFA = "Not in current ICFA";
 const NOT_IN_TRACT_LIST = "Not in Census Tract List. Contact CSE for update.";
@@ -612,7 +617,7 @@ app.use("*", cors());
 
 // Serve main HTML page at "/"
 app.get("/", async (c) => {
-	const filePath = path.join(process.cwd(), "public", "index.html");
+	const filePath = path.join(__dir, "..", "public", "index.html");
 	const html = await fs.promises.readFile(filePath, "utf8");
 	return c.html(html);
 });
@@ -763,7 +768,7 @@ app.post("/api/lookup-single", async (c) => {
 app.use(
 	"*",
 	serveStatic({
-		root: path.join(process.cwd(), "public"),
+		root: path.join(__dir, "..", "public"),
 	}),
 );
 

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -135,6 +135,19 @@ const BATCH_CONCURRENCY = (() => {
 		: DEFAULT_BATCH_CONCURRENCY;
 })();
 
+// Maximum number of batch jobs that may be actively processing at once.
+// Additional uploads are rejected with 429 until a slot opens.
+const DEFAULT_MAX_ACTIVE_JOBS = 3;
+const MAX_ACTIVE_JOBS = (() => {
+	const raw = process.env.MAX_ACTIVE_JOBS;
+	const parsed = raw ? Number(raw) : Number.NaN;
+	return Number.isFinite(parsed) && parsed > 0
+		? Math.floor(parsed)
+		: DEFAULT_MAX_ACTIVE_JOBS;
+})();
+
+let activeJobCount = 0;
+
 const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000;
 const JOB_TTL_MS = (() => {
 	const raw = process.env.JOB_TTL_MS;
@@ -407,6 +420,16 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 		return { ok: true, data: result };
 	} catch (err) {
 		if (err instanceof Error && err.name === "TimeoutError") {
+			// One automatic retry after a short pause — recovers most transient
+			// Smarty hangs without masking genuine rate-limit exhaustion.
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 2_000);
+			});
+			try {
+				return await lookupAddress(address);
+			} catch {
+				// Retry also timed out; give up with an actionable message.
+			}
 			return {
 				ok: false,
 				error:
@@ -650,6 +673,13 @@ app.post("/api/upload-csv", async (c) => {
 			return c.json({ error: "No CSV file uploaded" }, 400);
 		}
 
+		if (activeJobCount >= MAX_ACTIVE_JOBS) {
+			return c.json(
+				{ error: "Server busy — too many batches running, try again shortly" },
+				429,
+			);
+		}
+
 		const jobId = randomUUID();
 		const job: BatchJob = {
 			id: jobId,
@@ -661,13 +691,18 @@ app.post("/api/upload-csv", async (c) => {
 			results: [],
 		};
 		jobs.set(jobId, job);
+		activeJobCount += 1;
 
-		void processBatchFile(job, file).catch((err) => {
-			console.error("Batch processing failed:", err);
-			job.status = "failed";
-			job.errorMessage = "Batch processing failed";
-			job.finishedAt = Date.now();
-		});
+		void processBatchFile(job, file)
+			.catch((err) => {
+				console.error("Batch processing failed:", err);
+				job.status = "failed";
+				job.errorMessage = "Batch processing failed";
+				job.finishedAt = Date.now();
+			})
+			.finally(() => {
+				activeJobCount -= 1;
+			});
 
 		return c.json({ jobId }, 202);
 	} catch (err) {

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -422,15 +422,13 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 		return { ok: true, data: result };
 	} catch (err) {
 		if (err instanceof Error && err.name === "TimeoutError") {
-			// One automatic retry after a short pause — recovers most transient
-			// Smarty hangs without masking genuine rate-limit exhaustion.
-			await new Promise<void>((resolve) => {
-				setTimeout(resolve, 2_000);
-			});
-			try {
-				return await lookupAddress(address);
-			} catch {
-				// Retry also timed out; give up with an actionable message.
+			if (attempt < 1) {
+				// One automatic retry after a short pause — recovers most transient
+				// Smarty hangs without masking genuine rate-limit exhaustion.
+				await new Promise<void>((resolve) => {
+					setTimeout(resolve, 2_000);
+				});
+				return lookupAddress(address, attempt + 1);
 			}
 			return {
 				ok: false,

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -279,7 +279,10 @@ function getJob(id: string) {
 	return job;
 }
 
-async function lookupAddress(address: string): Promise<LookupResult> {
+async function lookupAddress(
+	address: string,
+	attempt = 0,
+): Promise<LookupResult> {
 	try {
 		// Step 1: Validate / geocode via Smarty.
 		// Try match=enhanced first (accepts non-USPS-deliverable physical locations).

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -119,6 +119,7 @@ const MAX_REQUEST_BODY_SIZE = (() => {
 })();
 
 const FETCH_TIMEOUT_MS = 10_000;
+const MAX_ADDRESS_LENGTH = 500;
 
 const DEFAULT_BATCH_CONCURRENCY = 3;
 const BATCH_CONCURRENCY = (() => {
@@ -264,19 +265,14 @@ function getJob(id: string) {
 async function lookupAddress(address: string): Promise<LookupResult> {
 	try {
 		// Step 1: Validate / geocode via Smarty.
-		// Credentials go in the Authorization header to keep them out of access logs.
 		// Try match=enhanced first (accepts non-USPS-deliverable physical locations).
 		// Fall back to match=invalid only on a successful 200 with no candidates —
 		// this corrects minor misspellings without retrying on rate-limit errors.
+		// Note: Smarty's US Street API requires credentials as query parameters;
+		// it does not support the Authorization header for this endpoint.
 		const smartyUrl = (match: string) =>
-			`https://us-street.api.smarty.com/street-address?street=${encodeURIComponent(address)}&match=${match}`;
-		const smartyHeaders = {
-			Authorization: `Smarty key=${SMARTY_AUTH_ID}:${SMARTY_AUTH_TOKEN}`,
-		};
-		const smartyOpts = {
-			headers: smartyHeaders,
-			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-		};
+			`https://us-street.api.smarty.com/street-address?auth-id=${SMARTY_AUTH_ID}&auth-token=${SMARTY_AUTH_TOKEN}&street=${encodeURIComponent(address)}&match=${match}`;
+		const smartyOpts = { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
 
 		let smartyResp = await fetch(smartyUrl("enhanced"), smartyOpts);
 		if (smartyResp.status === 429) {
@@ -517,7 +513,7 @@ async function processBatchFile(job: BatchJob, file: File) {
 				}
 
 				const address = extractAddress(row.data, columnMap);
-				if (!address) return;
+				if (!address || address.length > MAX_ADDRESS_LENGTH) return;
 
 				job.total += 1;
 				pending += 1;
@@ -744,6 +740,12 @@ app.post("/api/lookup-single", async (c) => {
 
 		if (!address) {
 			return c.json({ error: "No address provided" }, 400);
+		}
+		if (address.length > MAX_ADDRESS_LENGTH) {
+			return c.json(
+				{ error: `Address must be ${MAX_ADDRESS_LENGTH} characters or fewer` },
+				400,
+			);
 		}
 
 		const lookup = await lookupAddress(address);

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -291,7 +291,7 @@ async function lookupAddress(
 		// Note: Smarty's US Street API requires credentials as query parameters;
 		// it does not support the Authorization header for this endpoint.
 		const smartyUrl = (match: string) =>
-			`https://us-street.api.smarty.com/street-address?auth-id=${SMARTY_AUTH_ID}&auth-token=${SMARTY_AUTH_TOKEN}&street=${encodeURIComponent(address)}&match=${match}`;
+			`https://us-street.api.smarty.com/street-address?auth-id=${encodeURIComponent(SMARTY_AUTH_ID)}&auth-token=${encodeURIComponent(SMARTY_AUTH_TOKEN)}&street=${encodeURIComponent(address)}&match=${match}`;
 		let smartyResp = await fetch(smartyUrl("enhanced"), {
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
@@ -424,7 +424,7 @@ async function lookupAddress(
 
 		return { ok: true, data: result };
 	} catch (err) {
-		if (err instanceof Error && err.name === "TimeoutError") {
+		if (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")) {
 			if (attempt < 1) {
 				// One automatic retry after a short pause — recovers most transient
 				// Smarty hangs without masking genuine rate-limit exhaustion.

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -290,8 +290,15 @@ async function lookupAddress(
 		// this corrects minor misspellings without retrying on rate-limit errors.
 		// Note: Smarty's US Street API requires credentials as query parameters;
 		// it does not support the Authorization header for this endpoint.
-		const smartyUrl = (match: string) =>
-			`https://us-street.api.smarty.com/street-address?auth-id=${encodeURIComponent(SMARTY_AUTH_ID)}&auth-token=${encodeURIComponent(SMARTY_AUTH_TOKEN)}&street=${encodeURIComponent(address)}&match=${match}`;
+		const smartyUrl = (match: string) => {
+			const params = new URLSearchParams({
+				"auth-id": SMARTY_AUTH_ID,
+				"auth-token": SMARTY_AUTH_TOKEN,
+				street: address,
+				match,
+			});
+			return `https://us-street.api.smarty.com/street-address?${params}`;
+		};
 		let smartyResp = await fetch(smartyUrl("enhanced"), {
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
@@ -424,6 +431,7 @@ async function lookupAddress(
 
 		return { ok: true, data: result };
 	} catch (err) {
+		// AbortSignal.timeout() throws TimeoutError per spec; Bun may throw AbortError instead.
 		if (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")) {
 			if (attempt < 1) {
 				// One automatic retry after a short pause — recovers most transient

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -482,16 +482,15 @@ function extractAddress(
 }
 
 async function processBatchFile(job: BatchJob, file: File) {
-	const maxConcurrent = Math.max(1, BATCH_CONCURRENCY);
-	let pending = 0;
-	let parseDone = false;
-	let parserPaused = false;
-	let parserRef: Papa.Parser | null = null;
-
-	const waitForAll = new Promise<void>((resolve, reject) => {
-		const checkDone = () => {
-			if (parseDone && pending === 0) resolve();
-		};
+	// Phase 1: stream-parse the CSV and collect all valid addresses.
+	// PapaParse buffers small files in a single read, so pause/resume inside
+	// the step callback does not throttle concurrency — all step() calls fire
+	// synchronously before any pause can take effect. Collecting first and
+	// processing in a separate phase lets us apply a real semaphore.
+	const addresses = await new Promise<string[]>((resolve, reject) => {
+		const collected: string[] = [];
+		let columnMap: AddressColumnMap | undefined;
+		let detectionError: string | null = null;
 
 		const readable = Readable as typeof Readable & {
 			fromWeb?: (stream: ReadableStream) => Readable;
@@ -501,15 +500,10 @@ async function processBatchFile(job: BatchJob, file: File) {
 				? readable.fromWeb(file.stream())
 				: Readable.from(file.stream() as unknown as AsyncIterable<unknown>);
 
-		let columnMap: AddressColumnMap | undefined;
-		let detectionError: string | null = null;
-
 		Papa.parse<Record<string, string>>(fileStream, {
 			header: true,
 			skipEmptyLines: true,
 			step: (row, parser) => {
-				parserRef = parser;
-
 				if (columnMap === undefined) {
 					const fields = row.meta.fields ?? [];
 					const detected = detectAddressColumns(fields);
@@ -523,79 +517,91 @@ async function processBatchFile(job: BatchJob, file: File) {
 					}
 					columnMap = detected;
 				}
-
 				const address = extractAddress(row.data, columnMap);
-				if (!address || address.length > MAX_ADDRESS_LENGTH) return;
-
-				job.total += 1;
-				pending += 1;
-				if (!parserPaused && pending >= maxConcurrent) {
-					parser.pause();
-					parserPaused = true;
+				if (address && address.length <= MAX_ADDRESS_LENGTH) {
+					collected.push(address);
 				}
-
-				lookupAddress(address)
-					.then((lookup) => {
-						if (lookup.ok === true) {
-							job.results.push(lookup.data);
-						} else {
-							job.errors += 1;
-							job.results.push({ InputAddress: address, Error: lookup.error });
-							recordError(lookup.error, "batch", job.id);
-						}
-					})
-					.catch((err) => {
-						// Do not log the address (PII).
-						console.error("Error processing an address:", err);
-						job.errors += 1;
-						job.results.push({
-							InputAddress: address,
-							Error: "Processing failed",
-						});
-						recordError("Processing failed", "batch", job.id);
-					})
-					.finally(() => {
-						pending -= 1;
-						job.processed += 1;
-
-						if (!parseDone && parserPaused && pending < maxConcurrent) {
-							parserRef?.resume();
-							parserPaused = false;
-						}
-
-						checkDone();
-					});
 			},
 			complete: () => {
 				if (detectionError) {
 					reject(new UserError(detectionError));
 					return;
 				}
-				parseDone = true;
-				checkDone();
+				resolve(collected);
 			},
 			error: (err) => reject(err),
 		});
-	});
-
-	try {
-		await waitForAll;
-	} catch (err) {
+	}).catch((err: unknown) => {
 		if (!(err instanceof UserError))
 			console.error("Batch CSV parsing failed:", err);
 		job.status = "failed";
 		job.errorMessage =
-			err instanceof UserError ? err.message : "CSV parsing failed";
+			err instanceof UserError
+				? (err as UserError).message
+				: "CSV parsing failed";
 		job.finishedAt = Date.now();
-		return;
-	}
+		return null;
+	});
 
-	if (!job.total) {
+	if (addresses === null) return;
+
+	if (!addresses.length) {
 		job.status = "failed";
 		job.errorMessage = "CSV is empty or invalid format";
 		job.finishedAt = Date.now();
 		return;
 	}
+
+	job.total = addresses.length;
+
+	// Phase 2: process with a semaphore so BATCH_CONCURRENCY is enforced.
+	const maxConcurrent = Math.max(1, BATCH_CONCURRENCY);
+	let freeSlots = maxConcurrent;
+	const waiters: Array<() => void> = [];
+
+	function acquire(): Promise<void> {
+		if (freeSlots > 0) {
+			freeSlots -= 1;
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => {
+			waiters.push(resolve);
+		});
+	}
+
+	function release(): void {
+		const next = waiters.shift();
+		if (next) {
+			next();
+		} else {
+			freeSlots += 1;
+		}
+	}
+
+	await Promise.all(
+		addresses.map(async (address) => {
+			await acquire();
+			try {
+				const lookup = await lookupAddress(address);
+				if (lookup.ok === true) {
+					job.results.push(lookup.data);
+				} else {
+					job.errors += 1;
+					job.results.push({ InputAddress: address, Error: lookup.error });
+					recordError(lookup.error, "batch", job.id);
+				}
+			} catch (err) {
+				// Do not log the address (PII).
+				console.error("Error processing an address:", err);
+				job.errors += 1;
+				job.results.push({ InputAddress: address, Error: "Processing failed" });
+				recordError("Processing failed", "batch", job.id);
+			} finally {
+				release();
+				job.processed += 1;
+			}
+		}),
+	);
 
 	const ALL_FIELDS: string[] = [
 		"InputAddress",

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -146,6 +146,8 @@ const JOB_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
 const HALF_MILE_DAC_PREFIX = "dac 1/2 mile neighbor:";
 
+// ArcGIS overlay values can be prefixed with "preview for "; strip that and
+// normalize so eligibility checks aren't sensitive to whitespace / casing.
 function cleanOverlayLabel(value: unknown): string {
 	if (typeof value !== "string") return "";
 	return value.replace(/^preview\s+for\s+/i, "").trim();

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -213,7 +213,6 @@ const jobs = new Map<string, BatchJob>();
 
 type ErrorLogEntry = {
 	timestamp: string;
-	address: string;
 	error: string;
 	source: "batch" | "single";
 	jobId?: string;
@@ -223,14 +222,12 @@ const MAX_ERROR_LOG = 500;
 const errorLog: ErrorLogEntry[] = [];
 
 function recordError(
-	address: string,
 	error: string,
 	source: "batch" | "single",
 	jobId?: string,
 ) {
 	errorLog.push({
 		timestamp: new Date().toISOString(),
-		address,
 		error,
 		source,
 		jobId,
@@ -529,7 +526,7 @@ async function processBatchFile(job: BatchJob, file: File) {
 						} else {
 							job.errors += 1;
 							job.results.push({ InputAddress: address, Error: lookup.error });
-							recordError(address, lookup.error, "batch", job.id);
+							recordError(lookup.error, "batch", job.id);
 						}
 					})
 					.catch((err) => {
@@ -540,7 +537,7 @@ async function processBatchFile(job: BatchJob, file: File) {
 							InputAddress: address,
 							Error: "Processing failed",
 						});
-						recordError(address, "Processing failed", "batch", job.id);
+						recordError("Processing failed", "batch", job.id);
 					})
 					.finally(() => {
 						pending -= 1;
@@ -750,14 +747,14 @@ app.post("/api/lookup-single", async (c) => {
 
 		const lookup = await lookupAddress(address);
 		if (lookup.ok !== true) {
-			recordError(address, lookup.error, "single");
+			recordError(lookup.error, "single");
 			return c.json({ error: lookup.error }, lookup.status);
 		}
 
 		return c.json(lookup.data);
 	} catch (err) {
 		console.error("Single address lookup failed:", err);
-		recordError("unknown", "Address lookup failed", "single");
+		recordError("Address lookup failed", "single");
 		return c.json({ error: "Address lookup failed" }, 500);
 	}
 });

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -118,6 +118,8 @@ const MAX_REQUEST_BODY_SIZE = (() => {
 		: DEFAULT_MAX_REQUEST_BODY_SIZE;
 })();
 
+const FETCH_TIMEOUT_MS = 10_000;
+
 const DEFAULT_BATCH_CONCURRENCY = 3;
 const BATCH_CONCURRENCY = (() => {
 	const raw = process.env.BATCH_CONCURRENCY;
@@ -200,7 +202,7 @@ type BatchJob = {
 	errorMessage?: string;
 };
 
-type LookupErrorStatus = 400 | 404 | 500;
+type LookupErrorStatus = 400 | 404 | 429 | 500;
 
 type LookupResult =
 	| { ok: true; data: AddressResult }
@@ -262,18 +264,57 @@ function getJob(id: string) {
 async function lookupAddress(address: string): Promise<LookupResult> {
 	try {
 		// Step 1: Validate / geocode via Smarty.
+		// Credentials go in the Authorization header to keep them out of access logs.
 		// Try match=enhanced first (accepts non-USPS-deliverable physical locations).
-		// Fall back to match=invalid if enhanced returns nothing — this corrects
-		// minor street-name misspellings at the cost of accepting looser matches.
-		const smartyBase = `https://us-street.api.smarty.com/street-address?auth-id=${SMARTY_AUTH_ID}&auth-token=${SMARTY_AUTH_TOKEN}&street=${encodeURIComponent(address)}`;
-		let smartyData = await fetch(`${smartyBase}&match=enhanced`).then((r) =>
-			r.json(),
-		);
+		// Fall back to match=invalid only on a successful 200 with no candidates —
+		// this corrects minor misspellings without retrying on rate-limit errors.
+		const smartyUrl = (match: string) =>
+			`https://us-street.api.smarty.com/street-address?street=${encodeURIComponent(address)}&match=${match}`;
+		const smartyHeaders = {
+			Authorization: `Smarty key=${SMARTY_AUTH_ID}:${SMARTY_AUTH_TOKEN}`,
+		};
+		const smartyOpts = {
+			headers: smartyHeaders,
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		};
+
+		let smartyResp = await fetch(smartyUrl("enhanced"), smartyOpts);
+		if (smartyResp.status === 429) {
+			return {
+				ok: false,
+				error:
+					"Smarty rate limit exceeded — reduce batch size or wait before retrying",
+				status: 429,
+			};
+		}
+		if (!smartyResp.ok) {
+			return {
+				ok: false,
+				error: `Smarty error ${smartyResp.status}`,
+				status: 500,
+			};
+		}
+		let smartyData = await smartyResp.json();
 
 		if (!smartyData?.length) {
-			smartyData = await fetch(`${smartyBase}&match=invalid`).then((r) =>
-				r.json(),
-			);
+			// Only fall back when enhanced returned 200 with no candidates.
+			smartyResp = await fetch(smartyUrl("invalid"), smartyOpts);
+			if (smartyResp.status === 429) {
+				return {
+					ok: false,
+					error:
+						"Smarty rate limit exceeded — reduce batch size or wait before retrying",
+					status: 429,
+				};
+			}
+			if (!smartyResp.ok) {
+				return {
+					ok: false,
+					error: `Smarty error ${smartyResp.status}`,
+					status: 500,
+				};
+			}
+			smartyData = await smartyResp.json();
 		}
 
 		if (!smartyData?.length) {
@@ -294,7 +335,16 @@ async function lookupAddress(address: string): Promise<LookupResult> {
 
 		// Step 2: ArcGIS overlay
 		const arcgisUrl = `https://maps3.energycenter.org/arcgis/rest/services/sync/GPServer/LocOverlay_CT/execute?longitude=${lon}&latitude=${lat}&returnZ=false&returnM=false&returnTrueCurves=false&returnFeatureCollection=false&returnColumnName=false&simplifyFeatures=true&context=&f=pjson`;
-		const arcResp = await fetch(arcgisUrl);
+		const arcResp = await fetch(arcgisUrl, {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
+		if (!arcResp.ok) {
+			return {
+				ok: false,
+				error: `ArcGIS error ${arcResp.status}`,
+				status: 500,
+			};
+		}
 		const arcData = await arcResp.json();
 
 		const value = arcData?.results?.[0]?.value || {};

--- a/batch-tool/src/index.ts
+++ b/batch-tool/src/index.ts
@@ -515,6 +515,7 @@ async function processBatchFile(job: BatchJob, file: File) {
 	// processing in a separate phase lets us apply a real semaphore.
 	const addresses = await new Promise<string[]>((resolve, reject) => {
 		const collected: string[] = [];
+		const tooLong: string[] = [];
 		let columnMap: AddressColumnMap | undefined;
 		let detectionError: string | null = null;
 
@@ -544,14 +545,29 @@ async function processBatchFile(job: BatchJob, file: File) {
 					columnMap = detected;
 				}
 				const address = extractAddress(row.data, columnMap);
-				if (address && address.length <= MAX_ADDRESS_LENGTH) {
-					collected.push(address);
+				if (address) {
+					if (address.length <= MAX_ADDRESS_LENGTH) {
+						collected.push(address);
+					} else {
+						tooLong.push(address);
+					}
 				}
 			},
 			complete: () => {
 				if (detectionError) {
 					reject(new UserError(detectionError));
 					return;
+				}
+				if (tooLong.length) {
+					const tooLongError = `Address must be ${MAX_ADDRESS_LENGTH} characters or fewer`;
+					job.results.push(
+						...tooLong.map((address) => ({
+							InputAddress: address,
+							Error: tooLongError,
+						})),
+					);
+					job.errors += tooLong.length;
+					job.processed += tooLong.length;
 				}
 				resolve(collected);
 			},
@@ -571,60 +587,47 @@ async function processBatchFile(job: BatchJob, file: File) {
 
 	if (addresses === null) return;
 
-	if (!addresses.length) {
+	const totalRows = addresses.length + job.processed;
+	if (!totalRows) {
 		job.status = "failed";
 		job.errorMessage = "CSV is empty or invalid format";
 		job.finishedAt = Date.now();
 		return;
 	}
 
-	job.total = addresses.length;
+	job.total = totalRows;
 
-	// Phase 2: process with a semaphore so BATCH_CONCURRENCY is enforced.
+	// Phase 2: process with a worker pool so BATCH_CONCURRENCY is enforced
+	// without creating one promise per row.
 	const maxConcurrent = Math.max(1, BATCH_CONCURRENCY);
-	let freeSlots = maxConcurrent;
-	const waiters: Array<() => void> = [];
-
-	function acquire(): Promise<void> {
-		if (freeSlots > 0) {
-			freeSlots -= 1;
-			return Promise.resolve();
-		}
-		return new Promise<void>((resolve) => {
-			waiters.push(resolve);
-		});
-	}
-
-	function release(): void {
-		const next = waiters.shift();
-		if (next) {
-			next();
-		} else {
-			freeSlots += 1;
-		}
-	}
-
+	let nextIndex = 0;
+	const workerCount = Math.min(maxConcurrent, addresses.length);
 	await Promise.all(
-		addresses.map(async (address) => {
-			await acquire();
-			try {
-				const lookup = await lookupAddress(address);
-				if (lookup.ok === true) {
-					job.results.push(lookup.data);
-				} else {
+		Array.from({ length: workerCount }, async () => {
+			for (;;) {
+				const index = nextIndex;
+				nextIndex += 1;
+				if (index >= addresses.length) break;
+				const address = addresses[index];
+
+				try {
+					const lookup = await lookupAddress(address);
+					if (lookup.ok === true) {
+						job.results.push(lookup.data);
+					} else {
+						job.errors += 1;
+						job.results.push({ InputAddress: address, Error: lookup.error });
+						recordError(lookup.error, "batch", job.id);
+					}
+				} catch (err) {
+					// Do not log the address (PII).
+					console.error("Error processing an address:", err);
 					job.errors += 1;
-					job.results.push({ InputAddress: address, Error: lookup.error });
-					recordError(lookup.error, "batch", job.id);
+					job.results.push({ InputAddress: address, Error: "Processing failed" });
+					recordError("Processing failed", "batch", job.id);
+				} finally {
+					job.processed += 1;
 				}
-			} catch (err) {
-				// Do not log the address (PII).
-				console.error("Error processing an address:", err);
-				job.errors += 1;
-				job.results.push({ InputAddress: address, Error: "Processing failed" });
-				recordError("Processing failed", "batch", job.id);
-			} finally {
-				release();
-				job.processed += 1;
 			}
 		}),
 	);


### PR DESCRIPTION
## Summary

- **Flexible CSV address columns** — accepts single-column (`address`) and multi-column (`street`, `city`, `state`, `zip`) formats with case-insensitive alias matching; fails immediately with an actionable error if no recognized column is found
- **Concurrency fix** — PapaParse pause/resume cannot throttle small files (entire file buffers in one read, all `step()` calls fire synchronously). Replaced with a two-phase approach: collect addresses into an array, then process with a semaphore. `BATCH_CONCURRENCY` now actually works; error rate on 50-row batches dropped from ~35% to ~2%
- **Reliability** — HTTP status checks on Smarty and ArcGIS responses; 20s fetch timeout with `AbortSignal.timeout`; single automatic retry with 2s backoff on transient timeouts; address max-length validation (500 chars)
- **Concurrent job cap** — `MAX_ACTIVE_JOBS` (default 3) rejects new uploads with 429 when too many jobs are already processing, preventing unbounded Smarty load under concurrent use
- **PII fix** — `/api/errors` was logging the full address string; parameter removed, only error message/metadata retained
- **Static path fix** — server-relative paths used `process.cwd()` (breaks when launched from a different directory); switched to `import.meta.dir`
- **README** — documents single-column and multi-column CSV formats, alias list, and new `MAX_ACTIVE_JOBS` tuning variable

## Test plan

- [x] Single-column CSV (`addresses.csv`) — 0 errors
- [x] Multi-column CSV (`test_batch_tool.csv`, `address:street`/`address:city`/`address:state`/`address:zip`) — 0 errors
- [x] Bad column names — fails immediately with message listing found columns
- [x] Empty file and header-only file — fail with "CSV is empty or invalid format"
- [x] 50-row batch at concurrency=3 — ~41s, 1 "Address not found" (genuine), no rate-limit errors
- [x] 100-row batch — ~149s at concurrency=1, ~50s at concurrency=3, 2 "Address not found" (genuine)
- [x] Back-to-back 50-row batches — consistent low error rate, no degradation across runs
- [x] Two concurrent jobs — both complete correctly with interleaved progress
- [x] Job cap — 4 simultaneous uploads: 3 accepted (202), 1 rejected (429)
- [x] `/api/errors` — addresses no longer appear in error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)