### PR TITLE
Update income-limits date and PDF link to 2026

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -339,9 +339,9 @@ app.post("/api/overlay", async (c) => {
 				If your income falls below the listed threshold, you can visit the application portal
 				to complete the next steps for upgrading your home.
 				<br><br>
-				<em>Note:</em> Income limits are current as of April 23, 2025 and may change based on
+				<em>Note:</em> Income limits are current as of June 23, 2026 and may change based on
 				federal or state guidelines.
-				<a href="https://www.hcd.ca.gov/sites/default/files/docs/grants-and-funding/income-limits-2025.pdf"
+				<a href="https://www.hcd.ca.gov/sites/default/files/docs/grants-and-funding/income-limits-2026.pdf"
 					target="_blank" rel="noopener noreferrer">Click here</a>
 				to learn more about income limits.
 `;


### PR DESCRIPTION
## Summary
Follow-up to #19 (the 2026 income data update). The user-facing eligibility message in `backend/src/index.ts` still referenced the **2025** HCD limits, which is now stale.

- Effective date: `April 23, 2025` → **`June 23, 2026`**
- PDF link: `income-limits-2025.pdf` → `income-limits-2026.pdf`

## Source
Verified against HCD: the [Official State Income Limits for 2026](https://www.hcd.ca.gov/funding/income-limits/state-federal-income-limits/state) are effective **June 23, 2026**, and the corresponding [2026 PDF](https://www.hcd.ca.gov/sites/default/files/docs/grants-and-funding/income-limits-2026.pdf) is now live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)