### PR TITLE
Remove income-limits note from eligibility message

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -338,13 +338,16 @@ app.post("/api/overlay", async (c) => {
 				<br><br>
 				If your income falls below the listed threshold, you can visit the application portal
 				to complete the next steps for upgrading your home.
-				<br><br>
-				<em>Note:</em> Income limits are current as of June 23, 2026 and may change based on
-				federal or state guidelines.
-				<a href="https://www.hcd.ca.gov/sites/default/files/docs/grants-and-funding/income-limits-2026.pdf"
-					target="_blank" rel="noopener noreferrer">Click here</a>
-				to learn more about income limits.
 `;
+			// Income-limits note removed per request. To restore it, re-insert the
+			// following lines inside the `message` template literal above (just
+			// after "...upgrading your home."):
+			//     <br><br>
+			//     <em>Note:</em> Income limits are current as of June 23, 2026 and may change based on
+			//     federal or state guidelines.
+			//     <a href="https://www.hcd.ca.gov/sites/default/files/docs/grants-and-funding/income-limits-2026.pdf"
+			//         target="_blank" rel="noopener noreferrer">Click here</a>
+			//     to learn more about income limits.
 			return c.json({
 				success: true,
 				eligible: true,


### PR DESCRIPTION
## Summary
Removes the user-facing income-limits **note** from the Central-region eligibility message in `backend/src/index.ts`:
- Dropped: *"Income limits are current as of June 23, 2026 and may change based on federal or state guidelines"* and the "Click here" link to the HCD 2026 PDF.
- The income **table is unaffected** — `county_income` is still returned in the response and still renders for the user.
- The removed markup is preserved as a commented-out block immediately below the `message` template so it can be restored if needed.

## Note
Backend-only change, read at startup — deploying requires restarting the backend service (`:3000`); no widget rebuild and no batch-tool restart.

## Testing
Verified locally that the message renders without the note while the income table still appears. To be validated on the test server (feature branch) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)