### PR TITLE
Revert batch-tool port docs to 3001 (env-specific note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ or
  bun run src/index.ts
  ```
 
-Backend starts on `http://localhost:3000`. Batch-tool starts on `http://localhost:8282`.
+Backend starts on `http://localhost:3000`. Batch-tool starts on `http://localhost:3001`.
+
+> **Note:** The batch-tool port is configurable via `PORT` in `batch-tool/.env` and can differ per environment. The deployment server uses `3001`; some dev machines use `8282` (corporate security policies may block ports outside 8000–8999). If no `PORT` is set, the code falls back to `3100`. Make sure the batch-tool IIS `web.config` reverse-proxy target matches whatever port that environment runs on.
 
 ### 7. Test the Tool Locally
 
@@ -186,7 +188,7 @@ You should see:
      <rule name="BatchAPIReverseProxy" stopProcessing="true">
       <match url="^api/(.*)$" />
       <conditions logicalGrouping="MatchAll" trackAllCaptures="false" />
-      <action type="Rewrite" url="http://localhost:8282/api/{R:1}" />
+      <action type="Rewrite" url="http://localhost:3001/api/{R:1}" />
      </rule>
     </rules>
    </rewrite>
@@ -276,13 +278,13 @@ Restart IIS from powershell with `iisreset`
 
 ## Modification procedure
 
-If modifications are needed, you may need to force quit the currently running process. It doesn't always accept End commands from Task Scheduler. Remember there are two services running. The backend service is listening on Port `3000`, the batch-tool service on Port `8282`
+If modifications are needed, you may need to force quit the currently running process. It doesn't always accept End commands from Task Scheduler. Remember there are two services running. The backend service is listening on Port `3000`, the batch-tool service on Port `3001`
 
-1. Check to see if a previously started process is listening on port `3000` or `8282`:
+1. Check to see if a previously started process is listening on port `3000` or `3001`:
 
  ```powershell
  netstat -ano | findstr :3000
- netstat -ano | findstr :8282
+ netstat -ano | findstr :3001
  ```
 
 1. Force quit the running process:


### PR DESCRIPTION
## Summary
Corrects the batch-tool port documentation. #21 changed it to **8282** based on a dev machine's gitignored `.env`, but verification on the **deployment server** showed the batch tool actually runs on **3001** (`PORT=3001` in that box's `batch-tool/.env`, confirmed serving on 3001).

`.env` is per-environment and gitignored, so the README should document the deployment reality (3001) plus the fact that the port is configurable.

## Changes
- Restore **3001** in: the run/startup line, the IIS reverse-proxy `web.config` snippet, and the "Modification procedure" / `netstat` troubleshooting commands.
- Add a note: batch-tool port is set via `PORT` in `batch-tool/.env` and varies by environment — deployment uses `3001`, some dev machines use `8282` (corporate policy blocks ports outside 8000–8999), code default is `3100`; the IIS `web.config` proxy target must match the running port.

## Context
Supersedes the port portion of #21. Docs-only — no code change, nothing to redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)